### PR TITLE
competitor company profitability API 구현

### DIFF
--- a/src/main/java/SOLog/SOLog/controller/CompetitorInfoController.java
+++ b/src/main/java/SOLog/SOLog/controller/CompetitorInfoController.java
@@ -2,6 +2,7 @@ package SOLog.SOLog.controller;
 
 import SOLog.SOLog.domain.dto.CompetitorBalanceSheetDto;
 import SOLog.SOLog.domain.dto.CompetitorPriceDto;
+import SOLog.SOLog.domain.dto.CompetitorProfitabilityDto;
 import SOLog.SOLog.domain.dto.CompetitorValuationDto;
 import SOLog.SOLog.service.CompetitorInfoService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,5 +37,11 @@ public class CompetitorInfoController {
     @Operation(summary = "경쟁사 배교 내 valuation", description = "경재사들의 valuation 정보 반환")
     public List<CompetitorValuationDto> competitorValuation(@PathVariable String companyName) {
         return competitorInfoService.getCompetitorValuation(companyName);
+    }
+
+    @GetMapping("/{companyName}/profitability")
+    @Operation(summary = "경쟁사 배교 내 profitability", description = "경쟁사들의 profitability 정보 반환")
+    public List<CompetitorProfitabilityDto> competitorProfitability(@PathVariable String companyName) {
+        return competitorInfoService.getCompetitorProfitability(companyName);
     }
 }

--- a/src/main/java/SOLog/SOLog/domain/dto/CompetitorProfitabilityDto.java
+++ b/src/main/java/SOLog/SOLog/domain/dto/CompetitorProfitabilityDto.java
@@ -1,0 +1,13 @@
+package SOLog.SOLog.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CompetitorProfitabilityDto {
+    private String companyName;
+    private String ROE;
+    private String operatingMargin;
+    private String revenueGrowthRate;
+}

--- a/src/main/java/SOLog/SOLog/service/CompetitorInfoService.java
+++ b/src/main/java/SOLog/SOLog/service/CompetitorInfoService.java
@@ -2,6 +2,7 @@ package SOLog.SOLog.service;
 
 import SOLog.SOLog.domain.dto.CompetitorBalanceSheetDto;
 import SOLog.SOLog.domain.dto.CompetitorPriceDto;
+import SOLog.SOLog.domain.dto.CompetitorProfitabilityDto;
 import SOLog.SOLog.domain.dto.CompetitorValuationDto;
 import SOLog.SOLog.domain.entity.CompanyFinancialEntity;
 import SOLog.SOLog.repository.CompanyFinancialRepository;
@@ -81,5 +82,28 @@ public class CompetitorInfoService {
         }
 
         return competitorValuationDtos;
+    }
+
+    public List<CompetitorProfitabilityDto> getCompetitorProfitability(String companyName) {
+        List<String> competitorCompanies = relationRepository.findCompetitorNamesByCompanyName(companyName);
+        competitorCompanies.add(0, companyName);
+
+        List<CompetitorProfitabilityDto> competitorProfitabilityDtos = new ArrayList<>();
+
+        for(String company: competitorCompanies) {
+            CompanyFinancialEntity financialEntity = companyFinancialRepository.findByCompanyName(company);
+            if(financialEntity != null) {
+                competitorProfitabilityDtos.add(
+                        new CompetitorProfitabilityDto(
+                                company,
+                                financialEntity.getROE(),
+                                financialEntity.getOperatingMargin(),
+                                financialEntity.getRevenueGrowthRate()
+                        )
+                );
+            }
+        }
+
+        return competitorProfitabilityDtos;
     }
 }


### PR DESCRIPTION
## 개요

- competitor company profitability API 구현

## 작업사항

- #36 

## 변경로직

- competitor company profitability API 구현
- {companyName, OperatingMargin, RevenueGrowthRate} 형식으로 데이터 반환
